### PR TITLE
Bugfixes using new TTTC Variables

### DIFF
--- a/lua/classdrop/init.lua
+++ b/lua/classdrop/init.lua
@@ -8,9 +8,14 @@ hook.Add("TTTCDropClass", "TTTCClassDropAddon", function(ply)
 end)
 
 hook.Add("TTTCUpdateClass", "TTTCClassDropAddonPost", function(ply, old, new)
-    if not ply:HasWeapon("weapon_ttt_classdrop") and not ply.got_classdropper then
+    if not ply:HasWeapon("weapon_ttt_classdrop") and new then
         ply:Give("weapon_ttt_classdrop")
-        ply.got_classdropper = true
+    end
+end)
+
+hook.Add("PlayerSpawn", "TTTCRemoveClassOnSpawn", function(ply)
+    if GetRoundState() == ROUND_ACTIVE and not ply:HasWeapon("weapon_ttt_classdrop") and ply:HasCustomClass() and GetGlobalBool("ttt_classes_keep_on_respawn") then
+        ply:Give("weapon_ttt_classdrop")
     end
 end)
 
@@ -20,16 +25,6 @@ hook.Add("TTTPrepareRound", "TTTCDropClassPrepare", function()
     end
     
     DROPCLASSENTS = {}
-
-    for _, ply in ipairs(player.GetAll()) do
-        ply.got_classdropper = false
-    end
-end)
-
-hook.Add("TTTBeginRound", "TTTCDropClassBegin", function()
-    for _, ply in ipairs(player.GetAll()) do
-        ply.got_classdropper = false
-    end    
 end)
 
 hook.Add("TTTEndRound", "TTTCDropClassPrepare", function()
@@ -44,10 +39,6 @@ hook.Add("TTTEndRound", "TTTCDropClassPrepare", function()
     end
     
     DROPCLASSENTS = {}
-    
-    for _, ply in ipairs(player.GetAll()) do
-        ply.got_classdropper = false
-    end
 end)
 
 hook.Add("PlayerCanPickupWeapon", "TTTCPickupClassDropper", function(ply, wep)
@@ -59,11 +50,3 @@ hook.Add("PlayerCanPickupWeapon", "TTTCPickupClassDropper", function(ply, wep)
         end
     end
 end)
-
---[[
-hook.Add("PlayerDeath", "TTTCDropClassDeath", function(victim, inflictor, attacker)
-    if victim:HasWeapon("weapon_ttt_classdrop") then
-        DropCustomClass(victim)
-    end
-end)
-]]--

--- a/lua/classdrop/init.lua
+++ b/lua/classdrop/init.lua
@@ -13,8 +13,8 @@ hook.Add("TTTCUpdateClass", "TTTCClassDropAddonPost", function(ply, old, new)
     end
 end)
 
-hook.Add("PlayerSpawn", "TTTCRemoveClassOnSpawn", function(ply)
-    if GetRoundState() == ROUND_ACTIVE and not ply:HasWeapon("weapon_ttt_classdrop") and ply:HasCustomClass() and GetGlobalBool("ttt_classes_keep_on_respawn") then
+hook.Add("TTTCPlayerRespawnedWithClass", "TTTCGiveClassDropperOnSpawn", function(ply)
+    if not ply:HasWeapon("weapon_ttt_classdrop") then
         ply:Give("weapon_ttt_classdrop")
     end
 end)

--- a/lua/classdrop/server/functions.lua
+++ b/lua/classdrop/server/functions.lua
@@ -4,6 +4,9 @@ if SERVER then
 
         if not IsValid(ply) or not ply:IsPlayer() or not ply:HasCustomClass() then return end
 
+        --return if class is dropped on death (0 hp) and keeping class on respawn is enabled
+        if ply:Health() <= 0 and GetGlobalBool("ttt_classes_keep_on_respawn") then return end
+
         if ply:HasWeapon("weapon_ttt_classdrop") then
             ply:GetWeapon("weapon_ttt_classdrop").OldOwner = nil
         

--- a/lua/classdrop/server/functions.lua
+++ b/lua/classdrop/server/functions.lua
@@ -5,7 +5,7 @@ if SERVER then
         if not IsValid(ply) or not ply:IsPlayer() or not ply:HasCustomClass() then return end
 
         --return if class is dropped on death (0 hp) and keeping class on respawn is enabled
-        if ply:Health() <= 0 and GetGlobalBool("ttt_classes_keep_on_respawn") then return end
+        if ply:Health() <= 0 and GetGlobalBool("ttt_classes_keep_on_respawn") or ply:GetClassData().activeDuringDeath then return end
 
         if ply:HasWeapon("weapon_ttt_classdrop") then
             ply:GetWeapon("weapon_ttt_classdrop").OldOwner = nil


### PR DESCRIPTION
* classdropper is now only given once on class change and when someone respawned with his class
* correctly handling (dropping, removing etc.) for special classes with activeDuringDeath set to true


Note: We should move this addon to TTT2, since its closely related to TTTC.